### PR TITLE
Add anchors

### DIFF
--- a/github-repositories.html
+++ b/github-repositories.html
@@ -128,7 +128,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                            <tr>
+                                <tr><a id="APIM"></a>
                                     <td>
                                         WSO2 API Manager
                                     </td>
@@ -140,7 +140,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="BPS"></a>
                                     <td>
                                         WSO2 Business Process Server
                                     </td>
@@ -152,7 +152,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                 <tr>
+                                <tr><a id="DS"></a>
                                     <td>
                                         WSO2 Dashboard Server
                                     </td>
@@ -164,7 +164,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="DSS"></a>
                                     <td>
                                         WSO2 Data Services Server
                                     </td>
@@ -176,7 +176,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="EMM"></a>
                                     <td>
                                         WSO2 Enterprise Mobility Manager
                                     </td>
@@ -188,7 +188,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="ES"></a>
                                     <td>
                                         WSO2 Enterprise Store
                                     </td>
@@ -200,7 +200,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="ESB"></a>
                                     <td>
                                         WSO2 Enterprise Service Bus
                                     </td>
@@ -212,8 +212,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                               
-                                <tr>
+                                <tr><a id="IS"></a>
                                     <td>
                                         WSO2 Identity Server
                                     </td>
@@ -225,7 +224,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                 <tr>
+                                <tr><a id="IOTS"></a>
                                     <td>
                                         WSO2 IoT Server
                                     </td>
@@ -237,7 +236,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="MB"></a>
                                     <td>
                                         WSO2 Message Broker
                                     </td>
@@ -251,7 +250,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr><a id="ML"></a>
                                     <td>
                                         WSO2 Machine Learner
                                     </td>


### PR DESCRIPTION
Added anchors so we can link to specific products

## Purpose
When we link to this page from the product documentation, we want to be able to link to the specific section for the product they are interested in. 

## Goals
Make it faster for a user to get right to the appropriate repos for their product of interest and help avoid confusion.

## Approach
Added anchors in each of the rows. 

## User stories
N/A

## Release note
N/A

## Documentation
N/A; this is a documentation fix

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A