### PR TITLE
Fix anchors

### DIFF
--- a/github-repositories.html
+++ b/github-repositories.html
@@ -128,7 +128,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr><a id="APIM"></a>
+                                <tr id="APIM">
                                     <td>
                                         WSO2 API Manager
                                     </td>
@@ -140,7 +140,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="BPS"></a>
+                                <tr id="BPS">
                                     <td>
                                         WSO2 Business Process Server
                                     </td>
@@ -152,7 +152,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="DS"></a>
+                                <tr id="DS">
                                     <td>
                                         WSO2 Dashboard Server
                                     </td>
@@ -164,7 +164,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="DSS"></a>
+                                <tr id="DSS">
                                     <td>
                                         WSO2 Data Services Server
                                     </td>
@@ -176,7 +176,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="EMM"></a>
+                                <tr id="EMM">
                                     <td>
                                         WSO2 Enterprise Mobility Manager
                                     </td>
@@ -188,7 +188,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="ES"></a>
+                                <tr id="ES">
                                     <td>
                                         WSO2 Enterprise Store
                                     </td>
@@ -200,7 +200,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="ESB"></a>
+                                <tr id="ESB">
                                     <td>
                                         WSO2 Enterprise Service Bus
                                     </td>
@@ -212,7 +212,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="IS"></a>
+                                <tr id="IS">
                                     <td>
                                         WSO2 Identity Server
                                     </td>
@@ -224,7 +224,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="IOTS"></a>
+                                <tr id="IOTS">
                                     <td>
                                         WSO2 IoT Server
                                     </td>
@@ -236,7 +236,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="MB"></a>
+                                <tr id="MB">
                                     <td>
                                         WSO2 Message Broker
                                     </td>
@@ -250,7 +250,7 @@
                                         </ol>
                                     </td>
                                 </tr>
-                                <tr><a id="ML"></a>
+                                <tr id="ML">
                                     <td>
                                         WSO2 Machine Learner
                                     </td>


### PR DESCRIPTION
## Purpose
A name anchors don't work in table rows. Switched to TR IDs.

## Goals
Allow docs to point to specific spots in this page. 

## Approach
See above.

## User stories
N/A

## Release note
N/A

## Documentation
N/A; this is documentation

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/wso2/wso2.github.io/pull/2

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
Looked on StackOverflow for solution to linking to spot in tables.