### PR TITLE
Fix a link tag related to product-ml

### DIFF
--- a/github-repositories.html
+++ b/github-repositories.html
@@ -657,7 +657,7 @@
                                 <tr>
                                     <td>Machine Learner</td>
                                     <td>
-                                        <a href="https://github.com/wso2/product-m;.git" target="_blank">product-ml</a>
+                                        <a href="https://github.com/wso2/product-ml.git" target="_blank">product-ml</a>
                                     </td>
                                     <td>
                                         Maintains sources corresponding to building and packaging the WSO2 Machine Learner distribution.


### PR DESCRIPTION
## Purpose
> Fixing a bug in the link tag related to product-ml under product repositories. Reference #4 

## Goals
> Correct the link tag with the correct link

## Approach
> Trivial

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
>N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A
## Test environment
> N/A
 
## Learning
> N/A